### PR TITLE
Add calendar privacy usage descriptions to fix launch on modern macOS

### DIFF
--- a/Pomodoro/Pomodoro-Info.plist
+++ b/Pomodoro/Pomodoro-Info.plist
@@ -43,6 +43,10 @@
 	<true/>
 	<key>NSAppleScriptEnabled</key>
 	<true/>
+	<key>NSCalendarsFullAccessUsageDescription</key>
+	<string>Calendar access is required to add and update your pomodoro sessions.</string>
+	<key>NSCalendarsWriteOnlyAccessUsageDescription</key>
+	<string>This app adds pomodoro sessions to your calendar.</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright (c) 2009-2011 Ugo Landini</string>
 	<key>NSMainNibFile</key>


### PR DESCRIPTION
Fixes a launch-time crash on modern macOS caused by Calendar access without usage descriptions.

- Add NSCalendarsFullAccessUsageDescription
- Add NSCalendarsWriteOnlyAccessUsageDescription

Why: The app initializes CalendarStore in CalendarController::awakeFromNib and enumerates calendars. On macOS with TCC, missing usage strings causes immediate termination (appears as "app does not launch"). These strings were present in my WIP branch but not in master.

This change is minimal and unblocks launch with calendar features enabled.