### PR TITLE
Fix: restore menu actions and ensure notifications on macOS 14/15

### DIFF
--- a/Pomodoro/src/PomodoroController.m
+++ b/Pomodoro/src/PomodoroController.m
@@ -199,7 +199,238 @@
 	[internalInterruptPomodoro setEnabled:state == PomoTicking];
 }
 
-// ... (rest of file unchanged except awakeFromNib addition)
+#pragma mark ---- Menu actions ----
+
+-(IBAction)about:(id)sender {
+    if (!about) {
+        about = [[AboutController alloc] init];
+    }
+    [about showWindow:self];
+}
+
+-(IBAction)help:(id)sender {
+    if (!splash) {
+        splash = [[SplashController alloc] init];
+    }
+    [splash showWindow:self];
+}
+
+-(IBAction)setup:(id)sender {
+    [prefs makeKeyAndOrderFront:self];
+}
+
+-(IBAction)stats:(id)sender {
+    [stats showWindow:self];
+}
+
+- (IBAction) quickStats:(id)sender {
+    NSInteger time = pomodoro.time;
+    NSString* quickStats = [NSString stringWithFormat:NSLocalizedString(@"QuickStatistics",@"Quick statistic format string"),
+                            _pomodoroName, time/60, time%60,
+                            pomodoro.externallyInterrupted, pomodoro.internallyInterrupted, pomodoro.resumed,
+                            _globalPomodoroStarted, _globalPomodoroDone, _globalPomodoroReset,
+                            _dailyPomodoroStarted, _dailyPomodoroDone, _dailyPomodoroReset,
+                            _globalExternalInterruptions, _globalInternalInterruptions, _globalPomodoroResumed,
+                            _dailyExternalInterruptions, _dailyInternalInterruptions, _dailyPomodoroResumed,
+                            _pomodorosForLong - (longBreakCounter % _pomodorosForLong)
+                            ];
+    [growl growlAlert:quickStats title:NSLocalizedString(@"Quick Statistics",@"Growl header for quick statistics")];
+}
+
+-(IBAction)quit:(id)sender {
+    [NSApp terminate:self];
+}
+
+- (void) realStart {
+    [pomodoro start];
+    [self updateMenu];
+}
+
+-(IBAction) nameCanceled:(id)sender {
+    [namePanel close];
+    [[NSNotificationCenter defaultCenter] postNotificationName:_PMPomoNameCanceled object:namePanel];
+}
+
+-(IBAction) nameGiven:(id)sender {
+    if (![namePanel makeFirstResponder:namePanel]) {
+        [namePanel endEditingFor:nil];
+    }
+    [[NSNotificationCenter defaultCenter] postNotificationName:_PMPomoNameGiven object:namePanel];
+    [namePanel close];
+    [self realStart];
+}
+
+- (void) setFocusOnPomodoro {
+    SetFrontProcess(&psn);
+}
+
+- (IBAction) start: (id) sender {
+    if (_initialTime > 0) {
+        [about close];
+        [splash close];
+        [scriptPanel close];
+        [prefs close];
+        if ([longBreakCheckerTimer isValid]) {
+            [longBreakCheckerTimer invalidate];
+            longBreakCheckerTimer = nil;
+        }
+        [[NSNotificationCenter defaultCenter] postNotificationName:_PMPomoWillStart object:nil];
+        if ([self checkDefault:@"askBeforeStart"] && (@"direct" != sender)) {
+            [self setFocusOnPomodoro];
+            [namePanel makeKeyAndOrderFront:self];
+        } else {
+            [self realStart];
+        }
+    }
+}
+
+- (IBAction) finish: (id) sender {
+    [pomodoro finish];
+}
+
+- (IBAction) reset: (id) sender {
+    [pomodoro reset];
+    [self updateMenu];
+    [self showTimeOnStatusBar: _initialTime * 60];
+}
+
+- (IBAction) externalInterrupt: (id) sender {
+    [pomodoro externalInterruptFor: _interruptTime];
+    [self updateMenu];
+}
+
+- (IBAction) internalInterrupt: (id) sender {
+    [pomodoro internalInterruptFor:_interruptTime];
+    [self updateMenu];
+}
+
+-(IBAction) resume: (id) sender {
+    [pomodoro resume];
+    [self updateMenu];
+}
+
+#pragma mark ---- Pomodoro notifications methods ----
+
+-(void) pomodoroStarted:(NSNotification*) notification {
+    [[NSUserDefaults standardUserDefaults] setObject: [NSNumber numberWithInt:(_dailyPomodoroStarted)+1] forKey:@"dailyPomodoroStarted"];
+    [[NSUserDefaults standardUserDefaults] setObject: [NSNumber numberWithInt:(_globalPomodoroStarted)+1] forKey:@"globalPomodoroStarted"];
+    NSString* name = [NSString stringWithFormat:NSLocalizedString(@"Working on: %@",@"Tooltip for running Pomodoro"), _pomodoroName];
+    [statusItem setToolTip:name];
+}
+
+-(void) pomodoroExternallyInterrupted:(NSNotification*) notification {
+    [[NSUserDefaults standardUserDefaults] setObject: [NSNumber numberWithInt:(_dailyExternalInterruptions)+1] forKey:@"dailyExternalInterruptions"];
+    [[NSUserDefaults standardUserDefaults] setObject: [NSNumber numberWithInt:(_globalExternalInterruptions)+1] forKey:@"globalExternalInterruptions"];
+    NSString* name = [NSString stringWithFormat:NSLocalizedString(@"Externally Interrupted: %@",@"Tooltip for Interruption"), _pomodoroName];
+    [statusItem setToolTip:name];
+}
+
+-(void) pomodoroInternallyInterrupted:(NSNotification*) notification {
+    [[NSUserDefaults standardUserDefaults] setObject: [NSNumber numberWithInt:(_dailyInternalInterruptions)+1] forKey:@"dailyInternalInterruptions"];
+    [[NSUserDefaults standardUserDefaults] setObject: [NSNumber numberWithInt:(_globalInternalInterruptions)+1] forKey:@"globalInternalInterruptions"];
+    NSString* name = [NSString stringWithFormat:NSLocalizedString(@"Internally Interrupted: %@",@"Tooltip for Interruption"), _pomodoroName];
+    [statusItem setToolTip:name];
+}
+
+-(void) pomodoroInterruptionMaxTimeIsOver:(NSNotification*) notification {
+    [[NSUserDefaults standardUserDefaults] setObject: [NSNumber numberWithInt:(_dailyPomodoroReset)+1] forKey:@"dailyPomodoroReset"];
+    [[NSUserDefaults standardUserDefaults] setObject: [NSNumber numberWithInt:(_globalPomodoroReset)+1] forKey:@"globalPomodoroReset"];
+    NSString* name = [NSString stringWithFormat:NSLocalizedString(@"Last: %@ (interrupted)",@"Tooltip for interrupt-reset pomodoros"), _pomodoroName];
+    [statusItem setToolTip:name];
+    [self updateMenu];
+    [self showTimeOnStatusBar: _initialTime * 60];
+}
+
+-(void) pomodoroReset:(NSNotification*) notification {
+    [[NSUserDefaults standardUserDefaults] setObject: [NSNumber numberWithInt:(_dailyPomodoroReset)+1] forKey:@"dailyPomodoroReset"];
+    [[NSUserDefaults standardUserDefaults] setObject: [NSNumber numberWithInt:(_globalPomodoroReset)+1] forKey:@"globalPomodoroReset"];
+    NSString* name = [NSString stringWithFormat:NSLocalizedString(@"Last: %@ (reset)",@"Tooltip for reset pomodoro"), _pomodoroName];
+    [statusItem setToolTip:name];
+}
+
+-(void) pomodoroResumed:(NSNotification*) notification {
+    [[NSUserDefaults standardUserDefaults] setObject: [NSNumber numberWithInt:(_dailyPomodoroResumed)+1] forKey:@"dailyPomodoroResumed"];
+    [[NSUserDefaults standardUserDefaults] setObject: [NSNumber numberWithInt:(_globalPomodoroResumed)+1] forKey:@"globalPomodoroResumed"];
+    NSString* name = [NSString stringWithFormat:NSLocalizedString(@"Working on: %@",@"Tooltip for running Pomodoro"), _pomodoroName];
+    [statusItem setToolTip:name];
+    [statusItem setImage:pomodoroImage];
+}
+
+-(void) breakStarted:(NSNotification*) notification {
+    NSString* name = [NSString stringWithFormat:NSLocalizedString(@"Break after: %@",@"Tooltip for break"), _pomodoroName];
+    [statusItem setToolTip:name];
+    [self updateMenu];
+}
+
+-(void) breakFinished:(NSNotification*) notification {
+    NSString* name = [NSString stringWithFormat:NSLocalizedString(@"Just finished: %@",@"Tooltip for finished pomodoros"), _pomodoroName];
+    [statusItem setToolTip:name];
+    [self updateMenu];
+    if (![self checkDefault:@"mute"] && [self checkDefault:@"ringAtBreakEnabled"]) {
+        [ringingBreak play];
+    }
+    [self showTimeOnStatusBar: _initialTime * 60];
+    if (![self checkDefault:@"mute"] && [self checkDefault:@"autoPomodoroRestart"]) {
+        [self start:nil];
+    } else if ([self checkDefault:@"longbreakResetEnabled"]) {
+        longBreakCheckerTimer = [NSTimer timerWithTimeInterval:_longbreakResetTime*60
+                                                       target:self
+                                                     selector:@selector(longBreakCheckerFinished)
+                                                     userInfo:nil
+                                                      repeats:NO];
+        [[NSRunLoop currentRunLoop] addTimer:longBreakCheckerTimer forMode:NSRunLoopCommonModes];
+    }
+}
+
+-(void) pomodoroFinished:(NSNotification*) notification {
+    [[NSUserDefaults standardUserDefaults] setObject: [NSNumber numberWithInt:(_dailyPomodoroDone)+1] forKey:@"dailyPomodoroDone"];
+    [[NSUserDefaults standardUserDefaults] setObject: [NSNumber numberWithInt:(_globalPomodoroDone)+1] forKey:@"globalPomodoroDone"];
+    longBreakCounter++;
+    NSString* name = [NSString stringWithFormat:NSLocalizedString(@"Just finished: %@",@"Tooltip for finished pomodoros"), _pomodoroName];
+    [statusItem setToolTip:name];
+    Pomodoro* pomo = [notification object];
+    [stats.pomos newPomodoro:lround(pomo.realDuration/60.0) withExternalInterruptions:pomo.externallyInterrupted withInternalInterruptions: pomo.internallyInterrupted];
+    if (![self checkDefault:@"mute"] && [self checkDefault:@"ringAtEndEnabled"]) {
+        [ringing play];
+    }
+    if ([self checkDefault:@"breakEnabled"]) {
+        NSInteger time = _breakTime;
+        if (([self checkDefault:@"longbreakEnabled"]) && ((longBreakCounter % _pomodorosForLong) == 0)) {
+            time = _longbreakTime;
+        }
+        [self showTimeOnStatusBar: time * 60];
+        [pomodoro breakFor:time];
+    } else {
+        [self showTimeOnStatusBar: _initialTime * 60];
+        if ([self checkDefault:@"autoPomodoroRestart"]) {
+            [self start:nil];
+        }
+    }
+    [self updateMenu];
+    [stats saveState];
+}
+
+- (void) oncePerSecondBreak:(NSNotification*) notification {
+    NSInteger time = [[notification object] integerValue];
+    [self showTimeOnStatusBar: time];
+    if (![self checkDefault:@"mute"] && [self checkDefault:@"tickAtBreakEnabled"]) {
+        [tick play];
+    }
+    if ([self checkDefault:@"preventSleepDuringPomodoroBreak"]) {
+        UpdateSystemActivity(OverallAct);
+    }
+}
+
+- (void) oncePerSecond:(NSNotification*) notification {
+    NSInteger time = [[notification object] integerValue];
+    [self showTimeOnStatusBar: time];
+    if (![self checkDefault:@"mute"] && [self checkDefault:@"tickEnabled"]) {
+        [tick play];
+    }
+    if ([self checkDefault:@"preventSleepDuringPomodoro"]) {
+        UpdateSystemActivity(OverallAct);
+    }
+}
 
 #pragma mark ---- Lifecycle methods ----
 


### PR DESCRIPTION
Summary
- Restore PomodoroController IBAction methods and pomodoro notification handlers that were removed in 69de79ad (via PR #10). This resolves the non-responsive menu issue.
- Keep original status item behavior (menu assigned via setMenu:), avoiding UI overrides.
- Make notifications reliable on modern macOS:
  - Dynamically load the UserNotifications framework at runtime and set the UNUserNotificationCenter delegate so alerts show while the app is frontmost.
  - Request authorization on launch (existing call) and post via UN with a legacy NSUserNotification fallback when UN isn’t available.

Why
- Regression (#14): XIB wires actions to PomodoroController, but methods had been removed, so clicks were no-ops.
- On some systems the UN framework wasn’t auto-loaded when not linked, causing UN classes to be nil; legacy notifications are deprecated/suppressed, leading to no visible alerts.

Changes
- Pomodoro/src/PomodoroController.m: reintroduce actions: start/reset/finish/externalInterrupt/internalInterrupt/resume/about/help/setup/stats/quickStats/quit/nameGiven/nameCanceled and handlers for pomodoro events; restore original behavior for tick/ring/tooltips/state updates.
- Pomodoro/src/NotificationService.m: add runtime dlopen of UserNotifications.framework; retain UN + legacy fallback, and ensure delegates are set.

Testing
- Menu bar: Start/Reset/Finish/Interrupt/Resume all respond and update state/time label.
- Sounds: tick during timer; ring at end/break per preferences.
- Notifications: “Check Notifications” test shows banner; start/finish/interrupt/resume show notifications when enabled and not silenced by Focus.
- Calendar: if enabled, start creates event; finish updates end time.

Notes
- Scope is surgical; no changes to defaults or calendar logic.
- Follow-up: proceed with AppleScript triage (#5) in a separate PR with minimal scope as outlined.

Closes #14